### PR TITLE
Currently, if you have a negative Duration, the String returned from _getTimeString appears as -1:-2:-47.

### DIFF
--- a/lib/audio_video_progress_bar.dart
+++ b/lib/audio_video_progress_bar.dart
@@ -1024,15 +1024,27 @@ class _RenderProgressBar extends RenderBox {
   }
 
   String _getTimeString(Duration time) {
+    Duration newTime = time;
+    bool timeIsNegative = time.isNegative;
+    if (timeIsNegative) {
+      newTime = time.abs();
+    }
     final minutes =
-        time.inMinutes.remainder(Duration.minutesPerHour).toString();
-    final seconds = time.inSeconds
+        newTime.inMinutes.remainder(Duration.minutesPerHour).toString();
+    final seconds = newTime.inSeconds
         .remainder(Duration.secondsPerMinute)
         .toString()
         .padLeft(2, '0');
-    return time.inHours > 0
-        ? "${time.inHours}:${minutes.padLeft(2, "0")}:$seconds"
-        : "$minutes:$seconds";
+
+    if (timeIsNegative) {
+      return newTime.inHours > 0
+          ? "-${newTime.inHours}:${minutes.padLeft(2, "0")}:$seconds"
+          : "-$minutes:$seconds";
+    } else {
+      return newTime.inHours > 0
+          ? "${time.inHours}:${minutes.padLeft(2, "0")}:$seconds"
+          : "$minutes:$seconds";
+    }
   }
 
   @override


### PR DESCRIPTION
This change checks if the Duration value passed in is negative.
If it is, we set the timeIsNegative bool to true and convert the
Duration value to a positive number using .abs(). If the Duration
is negative then we return a String with a prefixed with '-'.

With this change, the String will appears as -1:02:47.

ps-id: e7372e7d-3ff1-428a-96f3-879b40ee32a6