### PR TITLE
If total value isNegative, return 0

### DIFF
--- a/lib/audio_video_progress_bar.dart
+++ b/lib/audio_video_progress_bar.dart
@@ -1017,7 +1017,7 @@ class _RenderProgressBar extends RenderBox {
   }
 
   double _proportionOfTotal(Duration duration) {
-    if (total.inMilliseconds == 0) {
+    if (total.inMilliseconds == 0 || total.isNegative) {
       return 0.0;
     }
     return duration.inMilliseconds / total.inMilliseconds;


### PR DESCRIPTION
I did this because when the progress bar total value is negative
it paints the progress bar too far to the left and it goes out
of the view. This way it stays at the 0 position.

ps-id: 5d6836a9-40eb-4baa-bf2f-3f1464454369